### PR TITLE
fixing Rails asset paths for CSS

### DIFF
--- a/opal/opal_hot_reloader/css_reloader.rb
+++ b/opal/opal_hot_reloader/css_reloader.rb
@@ -30,7 +30,7 @@ class OpalHotReloader
       else
         # Rails asset pipeline match
         url_base = File.basename(url).sub(/\.s?css+/, '').sub(/\.s?css+/, '')
-        href_base = File.basename(href).sub(/\.self-.*.css.+/, '')
+        href_base = File.basename(href).sub(/\.self-?.*.css.+/, '')
         url_base == href_base
       end
     


### PR DESCRIPTION
Fixes https://github.com/fkchang/opal-hot-reloader/issues/7

I'm guessing Rails changed how they do asset paths in this release, breaking your regex.