### PR TITLE
Create opal_hot_reloader.rb

### DIFF
--- a/opal/opal_hot_reloader.rb
+++ b/opal/opal_hot_reloader.rb
@@ -86,9 +86,15 @@ end
 def self.create_framework_aware_server(port, ping)
   if defined? ::React
     ReactrbPatches.patch!
-    @server = OpalHotReloader.new(port, ping) { React::Component.force_update! }
+    @server = OpalHotReloader.new(port, ping) do
+      if defined?(Hyperloop) && 
+         defined?(Hyperloop::ClientDrivers) &&
+         Hyperloop::ClientDrivers.respond_to?(:initialize_client_drivers_on_boot)
+        Hyperloop::ClientDrivers.initialize_client_drivers_on_boot 
+      end
+      React::Component.force_update!
+    end 
   else
-    puts "No framework detected"
     @server = OpalHotReloader.new(port, ping)
   end
   @server.listen


### PR DESCRIPTION
Rails actioncable is reset when code on the server changes.  This means that hot-reloader needs to notifiy hyperloop to reset the connection when it detects a code change, otherwise the connection is never restored.