### PR TITLE
Correct work with other languages. Added Encoding::UTF_8.

### DIFF
--- a/lib/opal_hot_reloader/server.rb
+++ b/lib/opal_hot_reloader/server.rb
@@ -66,7 +66,7 @@ module OpalHotReloader
 
     def send_updated_file(modified_file)
       if modified_file =~ /\.rb$/
-        file_contents = File.read(modified_file)
+        file_contents = File.read(modified_file).force_encoding(Encoding::UTF_8)
         update = {
           type: 'ruby',
           filename: modified_file,


### PR DESCRIPTION
Added `Encoding::UTF_8` for correctly passing file_contens and work with other languages in hot-reloader. In my case it was Russian, and before i had fix it, here was error:

`
ERROR -- : exception while processing events: "\xD0" on US-ASCII Backtrace:
hot-loader :  -- /Users/serzh/.rvm/gems/ruby-2.4.1/bundler/gems/opal-hot-reloader-fc099b3d8ea5/lib/opal_hot_reloader/server.rb:74:in 'encode'
hot-loader :  -- /Users/serzh/.rvm/gems/ruby-2.4.1/bundler/gems/opal-hot-reloader-fc099b3d8ea5/lib/opal_hot_reloader/server.rb:74:in 'to_json'
hot-loader :  -- /Users/serzh/.rvm/gems/ruby-2.4.1/bundler/gems/opal-hot-reloader-fc099b3d8ea5/lib/opal_hot_reloader/server.rb:74:in 'send_updated_file'
`

After adding this feature, **all works fine.**
Thanks.