### PR TITLE
makes opal hot reloader compatible with latest hyperloop

### DIFF
--- a/opal/opal_hot_reloader/reactrb_patches.rb
+++ b/opal/opal_hot_reloader/reactrb_patches.rb
@@ -1,5 +1,6 @@
 # patches to support reloading react.rb
 module ReactrbPatchModules
+  # add global force_update! method
   module ReactComponent
     def add_to_global_component_list(instance)
       (@global_component_list ||= Set.new).add instance
@@ -10,22 +11,63 @@ module ReactrbPatchModules
     end
 
     def force_update!
-      @global_component_list && @global_component_list.each(&:force_update!)
+      # components may be unmounted as a result of doing force_updates
+      # so copy the list, and then check before updating each component
+      return unless @global_component_list
+      components = @global_component_list.to_a
+      components.each do |comp|
+        next unless @global_component_list.include? comp
+        comp.force_update!
+      end
+    end
+  end
+
+  # patches to handle new react error boundry call back
+  module AddErrBoundry
+    def self.included(base)
+      return unless base.respond_to? :after_error
+      base.alias_method :pre_hot_loader_render, :render
+      base.after_error do |*err|
+        @err = err
+        force_update!
+      end
+      base.define_method :render do
+        @err ? parse_display_and_clear_error : pre_hot_loader_render
+      end
+    end
+
+    def parse_display_and_clear_error
+      e = @err[0]
+      component_stack = @err[1]['componentStack'].split("\n ")
+      @err = nil
+      display_error(e, component_stack)
+    end
+
+    def display_error(e, component_stack)
+      DIV do
+        DIV { "Uncaught error: #{e}" }
+        component_stack.each do |line|
+          DIV { line }
+        end
+      end
     end
   end
 end
 
+# React.rb needs to be patched so the we don't keep adding callbacks
 class ReactrbPatches
-  # React.rb needs to be patched so the we don't keep adding callbacks
   def self.patch!
     ::React::Component.extend ReactrbPatchModules::ReactComponent # works
 
     ::React::Callbacks.alias_method :original_run_callback, :run_callback # works
     # Easiest place to hook into all components lifecycles
     ::React::Callbacks.define_method(:run_callback) do |name, *args| # works
-      React::Component.add_to_global_component_list self if name == :before_mount
+      ::React::Component.add_to_global_component_list self if name == :before_mount
       original_run_callback name, *args
-      React::Component.remove_from_global_component_list self if name == :before_unmount
+      ::React::Component.remove_from_global_component_list self if name == :before_unmount
     end
+
+    return unless defined?(::React::TopLevelRailsComponent)
+    ::React::TopLevelRailsComponent.include ReactrbPatchModules::AddErrBoundry
   end
 end

--- a/opal/opal_hot_reloader/reactrb_patches.rb
+++ b/opal/opal_hot_reloader/reactrb_patches.rb
@@ -22,35 +22,6 @@ module ReactrbPatchModules
     end
   end
 
-  # patches to handle new react error boundry call back
-  module AddErrBoundry
-    def self.included(base)
-      base.alias_method :pre_hot_loader_render, :render
-      base.after_error do |*err|
-        @err = err
-        force_update!
-      end
-      base.define_method :render do
-        @err ? parse_display_and_clear_error : pre_hot_loader_render
-      end
-    end
-
-    def parse_display_and_clear_error
-      e = @err[0]
-      component_stack = @err[1]['componentStack'].split("\n ")
-      @err = nil
-      display_error(e, component_stack)
-    end
-
-    def display_error(e, component_stack)
-      DIV do
-        DIV { "Uncaught error: #{e}" }
-        component_stack.each do |line|
-          DIV { line }
-        end
-      end
-    end
-  end
   module AddForceUpdate
     # latest hyperloop already has a force_update! method, but legacy hot
     # reloader expects it to be defined in React::Component.

--- a/opal/opal_hot_reloader/reactrb_patches.rb
+++ b/opal/opal_hot_reloader/reactrb_patches.rb
@@ -13,19 +13,61 @@ module ReactrbPatchModules
       @global_component_list && @global_component_list.each(&:force_update!)
     end
   end
+  # patches to handle new react error boundry call back
+  module AddForceUpdate
+    # latest hyperloop already has a force_update! method, but legacy hot
+    # reloader expects it to be defined in React::Component.
+    # Once older versions of Hyperloop are deprecated this can be removed.
+    def force_update!
+      Hyperloop::Component.force_update!
+    end
+  end
+  module AddErrBoundry
+    def self.included(base)
+      base.after_error do |*err|
+        @err = err
+        Hyperloop::Component.force_update!
+      end
+      base.define_method :render do
+        @err ? parse_display_and_clear_error : top_level_render
+      end
+    end
+
+    def parse_display_and_clear_error
+      e = @err[0]
+      component_stack = @err[1]['componentStack'].split("\n ")
+      @err = nil
+      display_error(e, component_stack)
+    end
+
+    def display_error(e, component_stack)
+      DIV do
+        DIV { "Uncaught error: #{e}" }
+        component_stack.each do |line|
+          DIV { line }
+        end
+      end
+    end
+  end
 end
 
 class ReactrbPatches
-  # React.rb needs to be patched so the we don't keep adding callbacks
   def self.patch!
-    ::React::Component.extend ReactrbPatchModules::ReactComponent # works
+    if defined?(::React::TopLevelRailsComponent) && ::React::TopLevelRailsComponent.respond_to?(:after_error)
+       puts "new style"
+      ::React::TopLevelRailsComponent.include ReactrbPatchModules::AddErrBoundry
+      ::React::Component.extend ReactrbPatchModules::AddForceUpdate
+    else
+      puts "old style"
+      ::React::Component.extend ReactrbPatchModules::ReactComponent # works
 
-    ::React::Callbacks.alias_method :original_run_callback, :run_callback # works
-    # Easiest place to hook into all components lifecycles
-    ::React::Callbacks.define_method(:run_callback) do |name, *args| # works
-      React::Component.add_to_global_component_list self if name == :before_mount
-      original_run_callback name, *args
-      React::Component.remove_from_global_component_list self if name == :before_unmount
+      ::React::Callbacks.alias_method :original_run_callback, :run_callback # works
+      # Easiest place to hook into all components lifecycles
+      ::React::Callbacks.define_method(:run_callback) do |name, *args| # works
+        React::Component.add_to_global_component_list self if name == :before_mount
+        original_run_callback name, *args
+        React::Component.remove_from_global_component_list self if name == :before_unmount
+      end
     end
   end
 end


### PR DESCRIPTION
The big issue is that React has added error-boundries to catch errors, and so things have to be handled differently in the event of errors.  Also Hyperloop now has handlers for "force_update!" builtin.